### PR TITLE
replace http status codes with Response class constants

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,6 +3,7 @@
 namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
 
@@ -30,7 +31,7 @@ class Handler extends ExceptionHandler
 
         $this->renderable(function (NotFoundHttpException $e, $request) {
             if ($request->is('v1/events/*')) {
-                return json_response(404, 'Resource not found', null)->setStatusCode(404);
+                return json_response(Response::HTTP_NOT_FOUND, 'Resource not found', null)->setStatusCode(Response::HTTP_NOT_FOUND);
             }
             return null;
         });

--- a/app/Http/Controllers/Api/V1/Auth/AuthController.php
+++ b/app/Http/Controllers/Api/V1/Auth/AuthController.php
@@ -50,7 +50,7 @@ class AuthController extends Controller
 
         $token = auth()->user()->createToken('access_token')->accessToken;
 
-        return json_response(200, 'User has been logged in successfully', [
+        return json_response(Response::HTTP_OK, 'User has been logged in successfully', [
             'access_token' => $token,
         ]);
 

--- a/app/Http/Controllers/Api/V1/Auth/EmailValidationController.php
+++ b/app/Http/Controllers/Api/V1/Auth/EmailValidationController.php
@@ -5,16 +5,17 @@ namespace App\Http\Controllers\Api\V1\Auth;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\V1\Auth\EmailRequest;
 use App\Http\Requests\V1\Auth\ProfileImageRequest;
+use Illuminate\Http\Response;
 
 class EmailValidationController extends Controller
 {
     public function validateEmail(EmailRequest $request)
     {
-        return json_response(200, "Email is valid");
+        return json_response(Response::HTTP_OK, "Email is valid");
     }
 
     public function validateProfileImage(ProfileImageRequest $request)
     {
-        return json_response(200, "Profile image is valid");
+        return json_response(Response::HTTP_OK, "Profile image is valid");
     }
 }

--- a/app/Http/Controllers/Api/V1/Auth/EmailValidationController.php
+++ b/app/Http/Controllers/Api/V1/Auth/EmailValidationController.php
@@ -11,7 +11,7 @@ class EmailValidationController extends Controller
 {
     public function validateEmail(EmailRequest $request)
     {
-        return json_response(Response::HTTP_OK, "Email is valid");
+        return json_response(Response::HTTP_OK, 'Email is valid');
     }
 
     public function validateProfileImage(ProfileImageRequest $request)


### PR DESCRIPTION
As @CGCraftsman mentioned in #29, I observed that most of the response codes are present as constants of the `\Illuminate\Http\Response` | `(Symfony\Component\HttpFoundation\Response)` class. However, some remain in their raw form. 